### PR TITLE
fix: [sc-992] CLC app - Handle contentful sync failures

### DIFF
--- a/src/backup/index.ts
+++ b/src/backup/index.ts
@@ -127,6 +127,9 @@ export function withBackup<TDataSource extends Exportable & Syncable>(
         for(const item of entries) {
           await dataSource.index(item)
         }
+        if (present(token)) {
+          await dataSource.setToken(token)
+        }
       }
     }
   }

--- a/src/contentful/simpleClient.ts
+++ b/src/contentful/simpleClient.ts
@@ -122,7 +122,8 @@ export class SimpleContentfulClient {
       }
 
       if (resp.status != 200) {
-        throw new Error(`Unexpected status code ${resp.status} for '${path}'`)
+        // match the error message from the official client
+        throw new Error(`Request failed with status code ${resp.status}`)
       }
     } while (resp.status != 200)
 

--- a/src/dataSource/in-memory-data-source.spec.ts
+++ b/src/dataSource/in-memory-data-source.spec.ts
@@ -133,4 +133,46 @@ describe('InMemoryDataSource', () => {
       expect(titles).not.toContain('Main Stage Session 5')
     })
   })
+  
+  describe('import', () => {
+    it('replaces all existing entreis', async () => {
+      const newItems = [
+        {
+          sys: {
+            id: '1',
+            type: 'Entry',
+            contentType: {
+              sys: {
+                id: 'person'
+              }
+            }
+          },
+          fields: {
+            name: 'Alice'
+          }
+        },
+        {
+          sys: {
+            id: '2',
+            type: 'Asset'
+          },
+          fields: {
+            title: 'Bob'
+          }
+        }
+      ] as any[]
+      
+      // act
+      await instance.import(newItems, 'newToken')
+      
+      const entries = instance.getEntries()
+      const assets = instance.getAssets()
+
+      expect(entries.total).toEqual(1)
+      expect(entries.items.length).toEqual(1)
+      expect(assets.total).toEqual(1)
+      expect(assets.items.length).toEqual(1)
+      expect(instance.getToken()).toEqual('newToken')
+    })
+  })
 })

--- a/src/dataSource/in-memory-data-source.ts
+++ b/src/dataSource/in-memory-data-source.ts
@@ -5,10 +5,10 @@ import type { Asset, AssetCollection, Entry, EntryCollection, DeletedAsset, Dele
 import type { ContentfulDataSource } from '.'
 import { isAsset, isDeletedAsset, isDeletedEntry, isEntry } from '../util'
 import { Syncable } from '../syncEngine'
-import { Exportable } from '../backup'
+import { Exportable, Importable } from '../backup'
 
 
-export class InMemoryDataSource implements ContentfulDataSource, Syncable, Exportable {
+export class InMemoryDataSource implements ContentfulDataSource, Syncable, Exportable, Importable {
   private _entries: Map<string, SyncEntry | DeletedEntry>
   private _assets: Map<string, SyncAsset | DeletedAsset>
   private _syncToken: string | undefined | null

--- a/src/syncEngine/index.spec.ts
+++ b/src/syncEngine/index.spec.ts
@@ -3,6 +3,7 @@ import nock from 'nock'
 import { createClient } from 'contentful'
 import {SyncEngine} from '.'
 import { InMemoryDataSource } from '../dataSource/in-memory-data-source'
+import { SimpleContentfulClient } from '../contentful/simpleClient'
 
 const contentfulClient = createClient({
   accessToken: 'integration-test',
@@ -149,5 +150,40 @@ describe('SyncEngine', () => {
     
     // act
     await subject.sync()
+  })
+  
+  describe('with Simple Client', () => {
+    let simpleClient: SimpleContentfulClient
+    let fetch: typeof globalThis.fetch
+
+    beforeEach(() => {
+      fetch = require('node-fetch')
+      
+      simpleClient = new SimpleContentfulClient({
+        accessToken: 'integration-test',
+        space: 'xxxxxx',
+      }, 
+      fetch)
+      
+      subject = new SyncEngine(store, simpleClient)
+    })
+
+    it('does a full resync when the sync token is invalid', async () => {
+      nock('https://cdn.contentful.com')
+        .get('/spaces/xxxxxx/environments/master/sync?sync_token=badToken')
+        .reply(400, JSON.stringify({
+          'sys': {
+            'type':'Error',
+            'id':'BadRequest'
+          },
+          'message': 'The sync token you sent was invalid. Consider trying an initial sync by passing "initial=true".',
+          'requestId':'7553da98-bbd3-4d0c-bae4-e0ad1023e529'
+        }))
+        
+      store.setToken('badToken')
+      
+      // act
+      await subject.sync()
+    })
   })
 })

--- a/src/syncEngine/index.spec.ts
+++ b/src/syncEngine/index.spec.ts
@@ -132,4 +132,22 @@ describe('SyncEngine', () => {
     expect(store.getEntry('6RPLNBrHzAwg4X58WFkCBc')).toBeFalsy()
     expect(store.getAsset('1QJlrZxpJrSqaLOg0i1tvt')).toBeFalsy()
   })
+  
+  it('does a full resync when the sync token is invalid', async () => {
+    nock('https://cdn.contentful.com')
+      .get('/spaces/xxxxxx/environments/master/sync?sync_token=badToken')
+      .reply(400, JSON.stringify({
+        'sys': {
+          'type':'Error',
+          'id':'BadRequest'
+        },
+        'message': 'The sync token you sent was invalid. Consider trying an initial sync by passing "initial=true".',
+        'requestId':'7553da98-bbd3-4d0c-bae4-e0ad1023e529'
+      }))
+      
+    store.setToken('badToken')
+    
+    // act
+    await subject.sync()
+  })
 })

--- a/src/syncEngine/index.ts
+++ b/src/syncEngine/index.ts
@@ -72,7 +72,7 @@ export class SyncEngine {
     await this.dataSource.setToken(collection.nextSyncToken)
   }
 
-  private async fullResync(): Promise<void> {
+  public async fullResync(): Promise<void> {
     // We have to use "import" during a full resync, because the full resync doesn't include deletedEntries or deletedAssets.
     // So if some entries or assets were unpublished between the last successful sync and now, the only way to clear
     // them from the data source is to use "import".
@@ -103,11 +103,12 @@ function* iterateCollection(collection: SyncCollection): Generator<SyncItem> {
 export function withSync<DataSource extends Syncable>(
   dataSource: DataSource,
   client: Pick<ContentfulClientApi, 'sync'>
-): DataSource & Pick<SyncEngine, 'sync'> {
+): DataSource & Pick<SyncEngine, 'sync' | 'fullResync'> {
   const syncEngine = new SyncEngine(dataSource, client)
 
   return Object.assign(dataSource, {
-    sync: syncEngine.sync.bind(syncEngine)
+    sync: syncEngine.sync.bind(syncEngine),
+    fullResync: syncEngine.fullResync.bind(syncEngine)
   })
 }
 
@@ -122,7 +123,7 @@ export function withSync<DataSource extends Syncable>(
 export function addSync<DataSource extends Syncable>(
   dataSource: DataSource,
   client: Pick<ContentfulClientApi, 'sync'>
-): asserts dataSource is DataSource & Pick<SyncEngine, 'sync'> {
+): asserts dataSource is DataSource & Pick<SyncEngine, 'sync' | 'fullResync'> {
   withSync(dataSource, client)
 }
 

--- a/src/syncEngine/index.ts
+++ b/src/syncEngine/index.ts
@@ -51,9 +51,6 @@ export class SyncEngine {
       if (isError(e) && e.message == 'Request failed with status code 400') {
         return await this.fullResync()
       }
-      // if (e.message == 'The access token you sent could not be found or is invalid.') {
-      //   throw new Error('Invalid Contentful access token')
-      // }
       throw e
     }
 


### PR DESCRIPTION
We needed a way to do a full resync from initial whenever the sync API token becomes bad.
Some complications are:
* The full resync doesn't send back any deletedEntry or deletedAsset objects, but if any assets or entries have been deleted in the intervening time they still need to be removed
* The full resync ought to replace all the entries in the store atomically, i.e. there should not be an opportunity for anyone to query the store while it is in an incomplete state.

To accomplish this I introduced a new method, `import`, on the store interface.  The implementation in the InMemoryStore replaces its internal state without yielding back to the Event Loop, which accomplishes the atomicity requirement.

Then I changed the SyncEngine to handle a 400 bad request.  If a bad request happens, the SyncEngine will reissue the sync request with `initial=true`.  The full resync will then prefer the `import` method if it exists.

Story details: https://app.shortcut.com/watermark/story/992